### PR TITLE
Add state_class: measurement to allow historical data

### DIFF
--- a/docker/mqtt.sh
+++ b/docker/mqtt.sh
@@ -56,6 +56,7 @@ echo "$mapping" | while IFS='|' read name field unit; do
 {
   "name": "${name}",
   "state_topic": "orb_homeassistant/status",
+  "state_class": "measurement",
   "unit_of_measurement": "${unit}",
   "value_template": "{{ (value_json.${field}) | round(0) }}",
   "unique_id": "${unique_id}",


### PR DESCRIPTION
Add https://www.home-assistant.io/integrations/sensor.mqtt/#state_class set to measurement see https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes to have historical data. Right now by default you only get up to 10 days https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes After this change you will get historical values (min, max, average) at 1h intervals.