### PR TITLE
 mqtt.sh: suppress orb summary's per-poll banner, keep error output

### DIFF
--- a/docker/mqtt.sh
+++ b/docker/mqtt.sh
@@ -109,17 +109,6 @@ for entity in $CLEANUP_ENTITIES; do
     -t "$DISCOVERY_TOPIC" -n -r
 done
 
-# orb summary logs its startup banner to stderr on every invocation; only
-# stdout carries the JSON payload jq needs. That banner repeating every
-# MQTT_PAUSE seconds floods the host's journal, so route it to /dev/null by
-# default -- but keep it when mqtt_debug is on, since debugging should show
-# the child process's own logs rather than silently dropping them.
-if [ "$DEBUG_MODE" = "true" ]; then
-  exec 3>&2
-else
-  exec 3>/dev/null
-fi
-
 # mosquitto_pub -l keeps the connection open and publishes each line of input, outer loop
 # reconnects on drop, use keep-alive larger than MQTT_PAUSE to avoid needless pings.
 while true; do
@@ -127,8 +116,22 @@ while true; do
     # sleep first to avoid publishing zeroes on first iteration
     sleep "$MQTT_PAUSE"
 
-    # output a single line to mosquitto_pub
-    (/app/orb summary 2>&3 || echo '{}') | jq -c .
+    # output a single line to mosquitto_pub. orb summary prints a startup
+    # banner to stderr on every invocation, which would flood the journal at
+    # MQTT_PAUSE cadence -- so capture stderr in a variable (fd 3 carries the
+    # real stdout out of the command substitution) and only replay it when
+    # orb fails (it's the only diagnostic we have then) or mqtt_debug is on.
+    {
+      ORB_ERRS=$(/app/orb summary 2>&1 >&3)
+      ORB_RC=$?
+      if [ "$ORB_RC" -ne 0 ]; then
+        echo "orb summary failed (exit $ORB_RC):" >&2
+        [ -n "$ORB_ERRS" ] && printf '%s\n' "$ORB_ERRS" >&2
+        echo '{}'
+      elif [ "$DEBUG_MODE" = "true" ] && [ -n "$ORB_ERRS" ]; then
+        printf '%s\n' "$ORB_ERRS" >&2
+      fi
+    } 3>&1 | jq -c .
 
   done | mosquitto_pub -h "$MQTT_HOST" -p "$MQTT_PORT" -u "$MQTT_USER" -P "$MQTT_PASS" \
     -t "$STATE_TOPIC" -l -r -k $((MQTT_PAUSE * 2))

--- a/docker/mqtt.sh
+++ b/docker/mqtt.sh
@@ -117,7 +117,10 @@ while true; do
     sleep "$MQTT_PAUSE"
 
     # output a single line to mosquitto_pub
-    (/app/orb summary || echo '{}') | jq -c .
+    # orb summary logs its startup banner to stderr on every invocation; only
+    # stdout carries the JSON payload jq needs, so drop stderr here to avoid
+    # flooding the host's journal with a repeated banner every MQTT_PAUSE seconds
+    (/app/orb summary 2>/dev/null || echo '{}') | jq -c .
 
   done | mosquitto_pub -h "$MQTT_HOST" -p "$MQTT_PORT" -u "$MQTT_USER" -P "$MQTT_PASS" \
     -t "$STATE_TOPIC" -l -r -k $((MQTT_PAUSE * 2))

--- a/docker/mqtt.sh
+++ b/docker/mqtt.sh
@@ -109,6 +109,17 @@ for entity in $CLEANUP_ENTITIES; do
     -t "$DISCOVERY_TOPIC" -n -r
 done
 
+# orb summary logs its startup banner to stderr on every invocation; only
+# stdout carries the JSON payload jq needs. That banner repeating every
+# MQTT_PAUSE seconds floods the host's journal, so route it to /dev/null by
+# default -- but keep it when mqtt_debug is on, since debugging should show
+# the child process's own logs rather than silently dropping them.
+if [ "$DEBUG_MODE" = "true" ]; then
+  exec 3>&2
+else
+  exec 3>/dev/null
+fi
+
 # mosquitto_pub -l keeps the connection open and publishes each line of input, outer loop
 # reconnects on drop, use keep-alive larger than MQTT_PAUSE to avoid needless pings.
 while true; do
@@ -117,10 +128,7 @@ while true; do
     sleep "$MQTT_PAUSE"
 
     # output a single line to mosquitto_pub
-    # orb summary logs its startup banner to stderr on every invocation; only
-    # stdout carries the JSON payload jq needs, so drop stderr here to avoid
-    # flooding the host's journal with a repeated banner every MQTT_PAUSE seconds
-    (/app/orb summary 2>/dev/null || echo '{}') | jq -c .
+    (/app/orb summary 2>&3 || echo '{}') | jq -c .
 
   done | mosquitto_pub -h "$MQTT_HOST" -p "$MQTT_PORT" -u "$MQTT_USER" -P "$MQTT_PASS" \
     -t "$STATE_TOPIC" -l -r -k $((MQTT_PAUSE * 2))


### PR DESCRIPTION
## Problem

`mqtt.sh` runs `/app/orb summary` every `mqtt_frequency` seconds (default 5) to publish sensor state. Each invocation prints orb's multi-line startup banner to stderr, which lands in the add-on log — flooding the host's journal with an identical banner block every few seconds, creating a lot of noise.

## Fix

Each poll now captures `orb summary`'s stderr into a shell variable (via fd redirection inside the command substitution — stdout still streams straight to `jq`), then decides what to do with it based on the exit code:

- Success, `mqtt_debug` off (the normal case): stderr is discarded; the journal stays quiet.
- Success, `mqtt_debug` on: stderr is replayed to the log, so debugging still shows the child process's own output.
- Failure (any mode): logs orb summary failed (exit N): followed by the full captured stderr, then publishes {} as before.

The failure case is a deliberate improvement over simply redirecting stderr to /dev/null: previously a failing orb summary would silently publish empty payloads with no trace of why. Now the diagnostic is always preserved exactly when it matters. The approach keys off exit status rather than filtering banner text, so it won't break when orb changes its banner wording.

## Verification

- Exercised the poll logic under both `dash` and `busybox ash` (the add-on's /bin/sh) with stub orb binaries covering all three cases above — output matched expectations, including the exit code in the failure message.
- Deployed to a live Home Assistant instance: the previous container logged the banner every 5 seconds; the updated one has logged exactly one banner (the orb daemon's own startup) over an extended run, with sensor publishing unaffected. Verified logs
